### PR TITLE
PR: Use 101.3 kPa instead of 101 kPa for the atmospheric pressure at sea level

### DIFF
--- a/solarcalc.py
+++ b/solarcalc.py
@@ -296,7 +296,7 @@ def calc_solar_rad(lon_dd: float, lat_dd: float, alt: float,
 
         # Calculate the atmospheric pressure at the observation site using
         # Equation 3.7 in Campbell and Norman (1998).
-        Pa = 101 * np.exp(-1 * alt / 8200)  # TODO: correct 101 for 101.3.
+        Pa = 101.3 * np.exp(-1 * alt / 8200)
 
         # Calculate the optical air mass number using Equation 11.12 in
         # Campbell and Norman (1998).


### PR DESCRIPTION
Use 101.3 kPA instead of 101 kPA when calculating the atmospheric pressure at the observation site based on the atmospheric pressure at sea level and the site altitude.

So we now have:

`Pa = 101.3 * np.exp(-1 * alt / 8200)`

Instead of:

`Pa = 101 * np.exp(-1 * alt / 8200)`