### PR TITLE
PR: Fix the calculation of the longitudinal correction

### DIFF
--- a/solarcalc.py
+++ b/solarcalc.py
@@ -55,7 +55,7 @@ def load_demo_climatedata() -> pd.DataFrame:
         )
 
 
-def getET(dayofyear: int) -> float:
+def calc_eqn_of_time(dayofyear: int) -> float:
     """
     Calculate the Equation of Time correction (typically a 15-20 minutes
     correction depending on calendar day).
@@ -76,13 +76,16 @@ def getET(dayofyear: int) -> float:
         Calculated Equation of Time value in hours.
 
     """
-    ETcalc = (279.575 + 0.9856 * dayofyear) * np.pi / 180
+    f = (279.575 + 0.98565 * dayofyear) * np.pi / 180
 
     return (
-        -104.7 * np.sin(ETcalc) + 596.2 * np.sin(ETcalc * 2) +
-        4.3 * np.sin(3 * ETcalc) + -12.7 * np.sin(4 * ETcalc) +
-        -429.3 * np.cos(ETcalc) + -2.0 * np.cos(2 * ETcalc) +
-        19.3 * np.cos(3 * ETcalc)
+        -104.7 * np.sin(f) +
+        596.2 * np.sin(2 * f) +
+        4.3 * np.sin(3 * f) +
+        -12.7 * np.sin(4 * f) +
+        -429.3 * np.cos(f) +
+        -2.0 * np.cos(2 * f) +
+        19.3 * np.cos(3 * f)
         ) / 3600
 
 
@@ -255,7 +258,7 @@ def calc_solar_rad(lon_dd: float, lat_dd: float, alt: float,
         LC = calc_long_corr(lon_dd)
 
         # Gets correction for Equation of Time.
-        ET = getET(dayofyear)
+        ET = calc_eqn_of_time(dayofyear)
 
         # Calculate solar noon value.
         solarnoon = 12 - LC - ET

--- a/solarcalc.py
+++ b/solarcalc.py
@@ -86,24 +86,28 @@ def getET(dayofyear: int) -> float:
         ) / 3600
 
 
-def getLC(long2: float):
+def calc_long_corr(lon_dd: float) -> float:
     """
-    Calculate the longitudal correction.
+    Calculate the longitudinal correction.
 
     Parameters
     ----------
-    long2 : float
-        longitude of fieldsite in radians. Negative value if West of meridian
-        and positive value if East of meridian.
+    lon_dd : float
+        Longitude of fieldsite in decimal degrees. Negative value if West
+        of meridian and positive value if East of meridian.
 
     Returns
     -------
-    TYPE
-        DESCRIPTION.
+    float
+        Longitudinal correction in hours.
     """
-    # We assume longitude is in decimal format.
-    # Translates to 4 minutes for each degree
-    return long2 / 360 * 24
+    # Calculate the local standard time meridian.
+    lstm = lon_dd - lon_dd % (np.sign(lon_dd) * 15)
+
+    # Calculate the longitudinal correction in hours.
+    long_corr = (lon_dd - lstm) * (24 / 360)
+
+    return long_corr
 
 
 def calc_solar_declination(dayofyear: int) -> float:
@@ -248,7 +252,7 @@ def calc_solar_rad(lon_dd: float, lat_dd: float, alt: float,
 
     for i, dayofyear in enumerate(climate_data.index.dayofyear):
         # Calculate LC correction to solar noon.
-        LC = getLC(lon_rad)
+        LC = calc_long_corr(lon_dd)
 
         # Gets correction for Equation of Time.
         ET = getET(dayofyear)

--- a/solarcalc.py
+++ b/solarcalc.py
@@ -251,7 +251,7 @@ def calc_solar_rad(lon_dd: float, lat_dd: float, alt: float,
     lon_rad = np.radians(lon_dd)
 
     for i, dayofyear in enumerate(climate_data.index.dayofyear):
-        # Calculate LC correction to solar noon.
+        # Calculate the longitudinal correction to solar noon.
         LC = calc_long_corr(lon_dd)
 
         # Gets correction for Equation of Time.

--- a/tests/test_solarcalc.py
+++ b/tests/test_solarcalc.py
@@ -49,3 +49,29 @@ def test_calc_eqn_of_time(datetimes):
     err = np.abs(results - expected_results)
     assert np.all(err < 0.3)
 
+
+def test_calc_solar_noon(datetimes):
+    """
+    Test that solar noon is calculated as expected.
+    """
+    lon_dd = -74.351267
+    LC = calc_long_corr(lon_dd)
+    ET = calc_eqn_of_time(datetimes.dayofyear.values)
+    solarnoon = 12 - LC - ET
+
+    # https://gml.noaa.gov/grad/solcalc/
+    # Values corrected for daylight saving time change.
+    expected_results = np.array([
+        12 + 0/60 + 50/3600 + 1,
+        13 + 1/60 + 38/3600,
+        12 + 58/60 + 55/3600,
+        13 + 1/60 + 7/3600,
+        11 + 44/60 + 55/3600 + 1
+        ])
+
+    err = np.abs(solarnoon - expected_results)
+    assert np.all(err < 0.0035)
+
+
+if __name__ == "__main__":
+    pytest.main(['-x', osp.basename(__file__), '-vv', '-rw', '-s'])

--- a/tests/test_solarcalc.py
+++ b/tests/test_solarcalc.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright © Jean-Sébastien Gosselin
+# Licensed under the terms of the MIT License
+# (https://github.com/jnsebgosselin/appconfigs)
+# -----------------------------------------------------------------------------
+
+# ---- Standard imports
+import os
+import os.path as osp
+from datetime import datetime
+
+# ---- Third party imports
+import pytest
+import pandas as pd
+import numpy as np
+
+# ---- Local imports
+from solarcalc import calc_long_corr, calc_eqn_of_time
+
+
+@pytest.fixture
+def datetimes():
+    return pd.to_datetime([
+        datetime(2000, 1, 1),
+        datetime(2000, 3, 31),
+        datetime(2000, 6, 19),
+        datetime(2000, 8, 18),
+        datetime(2000, 11, 26)
+        ])
+
+
+# =============================================================================
+# ---- Tests
+# =============================================================================
+def test_calc_eqn_of_time(datetimes):
+    """
+    Test that the Equation of Time is calculated as expected.
+    """
+    results = calc_eqn_of_time(datetimes.dayofyear.values) * 60
+
+    # Table 11.1 in Campbell, G.S. and J.M. Norman (1998).
+    expected_results = np.array([-0.057, -0.072, -0.019, -0.065, 0.213]) * 60
+    err = np.abs(results - expected_results)
+    assert np.all(err < 0.3)
+
+    # https://gml.noaa.gov/grad/solcalc/
+    expected_results = np.array([-3.19, -4.1, -1.4, -3.83, 12.65])
+    err = np.abs(results - expected_results)
+    assert np.all(err < 0.3)
+

--- a/tests/test_solarcalc.py
+++ b/tests/test_solarcalc.py
@@ -6,7 +6,6 @@
 # -----------------------------------------------------------------------------
 
 # ---- Standard imports
-import os
 import os.path as osp
 from datetime import datetime
 


### PR DESCRIPTION
The longitudinal correction in the original source code of SolarCalc.jar (version 1.1, Jan. 2006) is not calculated correctly.

First the function `getLC`, which is used to calculate the longitudinal correction, assumes a longitudinal coordinate in decimal degree as argument, but the main function calls it with a  longitude coordinate in radians instead.

Secondly, the local standard time meridian is not calculated and taken into account in the calculation.

From Campbell, G.S. and J.M. Norman (1998), we have:

![image](https://user-images.githubusercontent.com/10170372/143285506-d6e7da03-b227-40ae-a4b8-5eda254dbfff.png)


This PR correct these two issues, so that LC is now calculated as:

```
# Calculate the local standard time meridian.
lstm = lon_dd - lon_dd % (np.sign(lon_dd) * 15)

# Calculate the longitudinal correction in hours.
long_corr = (lon_dd - lstm) * (24 / 360)
```