### PR TITLE
PR: Fix pre-rain condition when setting the value of the atmospheric transmittance (tau) 

### DIFF
--- a/solarcalc.py
+++ b/solarcalc.py
@@ -285,8 +285,7 @@ def calc_solar_rad(lon_dd: float, lat_dd: float, alt: float,
             tau = 0.30
 
         # Assign pre-rain days to 80% of tau value ?
-
-        if i > 0 and rain[i] == 0 and rain[i - 1] == 1:
+        if i < (len(climate_data) - 1) and rain[i] == 0 and rain[i + 1] == 1:
             tau = 0.60
 
         # If airtemperature rise is less than 10 --> lower tau value

--- a/solarcalc.py
+++ b/solarcalc.py
@@ -341,6 +341,7 @@ def calc_solar_rad(lon_dd: float, lat_dd: float, alt: float,
             start=climate_data.index[0],
             end=climate_data.index[-1] + pd.Timedelta('23H'),
             freq='H'))
+    solarcalc.index.name = 'datetime'
     solarcalc['solar_rad_W/m2'] = daily_solar_rad
     solarcalc['deltat_degC'] = deltat_array
     solarcalc['tau'] = tao_array

--- a/tests/test_solarcalc.py
+++ b/tests/test_solarcalc.py
@@ -15,7 +15,8 @@ import pandas as pd
 import numpy as np
 
 # ---- Local imports
-from solarcalc import calc_long_corr, calc_eqn_of_time
+from solarcalc import (calc_long_corr, calc_eqn_of_time, calc_solar_rad,
+                       load_demo_climatedata)
 
 
 @pytest.fixture
@@ -70,6 +71,32 @@ def test_calc_solar_noon(datetimes):
 
     err = np.abs(solarnoon - expected_results)
     assert np.all(err < 0.0035)
+
+
+def test_solar_calc():
+    """
+    Test that global solar radiation is calculated as expected.
+    """
+    expected_results = pd.read_csv(
+        osp.join(osp.dirname(__file__), 'output_solarcalc_demo.csv'),
+        header=0,
+        parse_dates=['datetime'],
+        index_col='datetime',
+        dtype={'solar_rad_W/m2': 'float',
+               'solar_rad_W/m2': 'float',
+               'tau': 'float'}
+        ).round(8)
+
+    climate_data = load_demo_climatedata()
+    solar_rad = calc_solar_rad(
+        lon_dd=-76.4687209,
+        lat_dd=56.5213541,
+        alt=100,
+        climate_data=climate_data
+        ).round(8)
+
+    assert (expected_results.index == solar_rad.index).all()
+    assert expected_results.values.tolist() == solar_rad.values.tolist()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In the original source code of SolarCalc.jar (version 1.1, Jan. 2006), pre-rain conditions were determined by looking at day `i` and day `i - 1`.

If we look at `i - 1`, this corresponds to post-rain condition, not pre-rain. We need to look at day `i + 1` for pre-rain.