### PR TITLE
PR: Use floats to represent deltaT instead of integers

### DIFF
--- a/solarcalc.py
+++ b/solarcalc.py
@@ -242,8 +242,8 @@ def calc_solar_rad(lon_dd: float, lat_dd: float, alt: float,
     """
     # Convert rain[day of year] = 1 if rain and rain = 0 if no rain.
     rain = (climate_data['ptot_mm'] > 1).values.astype(int)
-    deltaT = (climate_data['tamax_degC'].astype(int) -
-              climate_data['tamin_degC'].astype(int)).abs().values
+    deltaT = (climate_data['tamax_degC'] -
+              climate_data['tamin_degC']).abs().values
 
     daily_solar_rad = []
     tao_array = []


### PR DESCRIPTION
The amplitude of the air temperature variation ('deltaT ') was calculated using integers in the original source code of SolarCalc.jar (version 1.1, Jan. 2006).

This PR change this so that 'deltaT ' is now calculated and represented with float numbers.